### PR TITLE
Made Kitchen bump app

### DIFF
--- a/kitchenBump.py
+++ b/kitchenBump.py
@@ -15,11 +15,11 @@ from time import sleep
 # order each salad in first column,
 # close order
 # Function assumes you are at the main menu where the Green salad button is displayed
-def bump(bumpIterations):
+def bump():
     while True:
         try:
             pyautogui.click(x=500, y=500) # Click anywhere to ensure Kitchen.exe is in Focus()
-            pyautogui.press(b) # bump the order from the screen
+            pyautogui.press('b') # bump the order from the screen
 
         except TypeError:
             pyautogui.alert('Invalid operation!')

--- a/kitchenMain.py
+++ b/kitchenMain.py
@@ -2,7 +2,7 @@ import pyautogui
 import time
 from kitchenBump import bump
 # Adds a pause between all actions
-pyautogui.PAUSE = .01
+pyautogui.PAUSE = .1
 # Moving mouse to upper-left will abort program when true
 pyautogui.FAILSAFE = True
 
@@ -18,12 +18,13 @@ pyautogui.FAILSAFE = True
 
 # Click anywhere on the monitor
 # press the "b" key
-# wait 1 second
+# wait 0.1 second
 # press the "b" key
+# this will repeat until stopped
 
 def kitchenMain():
     # add functions here
-    bump(3500) # bumps orders
+    bump() # bumps orders
 
 if __name__ == '__main__':
     pyautogui.alert('Ensure Kitchen is running and in focus()!')


### PR DESCRIPTION
Set program to run by clicking the screen to bring kitchen.exe into focus.
With kitchen.exe in focus, the "b" key is pressed to bump the order from the screen.

Modified kitchenMain to run independently of main and orderSalad.

May need to add 10 second delay to start of program.
After testing, will need to see if 0.1 seconds is too fast for bumps.